### PR TITLE
Enable regex for license

### DIFF
--- a/test.js
+++ b/test.js
@@ -2,12 +2,10 @@
 const assert = require('assert')
 const validate = require('./validate.js')
 
-const input = `# standard-linter
-`
-
-// TODO Add Unit tests
-
 describe('validate file', () => {
+  const input = `# standard-linter
+  `
+
   it('reads some file', function () {
     const data = validate(input, './standard-linter/README.md')
     assert(data !== null, 'File should exist.')
@@ -24,17 +22,55 @@ describe('validate file', () => {
   })
 
   it('needs a markdown format', function() {
-    const data = validate(input, './standard-linter/REAMDE.md')
+    const data = validate(input, './standard-linter/README.md')
     assert.equal(data.markdown, true)
   })
 
   it('only accepts .md', function() {
-    const data = validate(input, './standard-linter/REAMDE.markdown')
+    const data = validate(input, './standard-linter/README.markdown')
     assert.equal(data.markdown, false)
   })
 
   it('accepts no other file types', function() {
-    const data = validate(input, './standard-linter/REAMDE.txt')
+    const data = validate(input, './standard-linter/README.txt')
     assert.equal(data.markdown, false)
+  })
+})
+
+describe('validate license', () => {
+  it('Checks for an MIT license', function () {
+    const license = `# standard-linter
+
+    [MIT](LICENSE) © 2017 Joe
+    `
+    const data = validate(license,  './standard-linter/README.md')
+    assert(data.mitLicense[0] === '[MIT](LICENSE)', 'License exists.')
+  })
+
+  it('Allows valid file types for license', function () {
+    const license = `# standard-linter
+
+    [MIT](LICENSE.md) © 2017 Joe
+    `
+    const data = validate(license,  './standard-linter/README.md')
+    assert(data.mitLicense !== null, 'License has a valid filetype.')
+  })
+
+  it('Disallows illegal file types for license', function () {
+    const license = `# standard-linter
+
+    [MIT](LICENSE.s) © 2017 Joe
+    `
+    const data = validate(license,  './standard-linter/README.md')
+    assert(data.mitLicense === null, 'License is invalid filetype.')
+  })
+
+  it('Ignores case for license', function () {
+    const license = `# standard-linter
+
+    [MIT](license) © 2017 Joe
+    `
+    const data = validate(license,  './standard-linter/README.md')
+    assert(data.mitLicense !== null, 'License is lowercase.')
   })
 })

--- a/validate.js
+++ b/validate.js
@@ -48,7 +48,7 @@ module.exports = function validate (data, path, opts) {
     delete check.install
     delete check.usage
   } else {
-    check.mitLicense = ('' + data).match(new RegExp(escapeRegExp('[MIT](LICENSE)')))
+    check.mitLicense = ('' + data).match(new RegExp('\\[MIT\\]\\(LICENSE(\.(md|txt))?\\)', 'i'))
   }
   check.copyright = ('' + data).match('©')
   check.copyrightYear = ('' + data).match('© [0-9\-]+')


### PR DESCRIPTION
This adds tests for file extensions and enables the regex to catch them for the license section. See #5. This closes #4.